### PR TITLE
fix: npm publishing auth via trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request introduces a minor update to the CI workflow and improves error handling in the test suite for automatic tool selection across providers. The most significant changes are the removal of the explicit NPM token from the publish workflow and enhanced handling of known validation errors in the tests.

### CI/CD Workflow

* Removed the explicit `NODE_AUTH_TOKEN` environment variable from the npm publish step in `.github/workflows/publish.yml`, likely relying on default GitHub Actions authentication for npm publishing.

### Test Suite Improvements

* Wrapped the agent execution in a `try-catch` block in `tests/volcano.flow.test.ts` to handle provider-specific validation errors.
* Added logic to skip tests for the Llama provider when a known `ValidationError` occurs, logging the error for visibility and preventing test failures due to this known limitation.