### PR TITLE
fix: npm publish ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm to support trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
This pull request makes a small update to the npm setup in the `.github/workflows/publish.yml` workflow to support trusted publishing.

* Added a step to update npm to the latest version before installing dependencies, ensuring compatibility with trusted publishing.